### PR TITLE
Add a dist attribute to XML <body> tags so planet icons won't collide

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,9 @@ AC_PROG_CC
 AM_PROG_CC_C_O
 AM_PROG_AR
 AC_PROG_LIBTOOL
+AC_SEARCH_LIBS([fabs], [m], [], [
+    AC_MSG_ERROR([Unable to find the fabs() function])
+])
 AC_PATH_PROGS(PERL, [perl5 perl])
 AC_PATH_PROGS(WGET, [wget])
 AC_PATH_PROGS(CURL, [curl])

--- a/src/resources/ui/chart-default.xsl
+++ b/src/resources/ui/chart-default.xsl
@@ -567,7 +567,7 @@
                                     </line>
                                     <use>
                                         <xsl:attribute name="xlink:href"><xsl:value-of select="concat('#', $planet_base, '_tmpl')"/></xsl:attribute>
-                                        <xsl:attribute name="transform"><xsl:value-of select="concat('translate(330,-15) rotate(', @degree - $asc_rotate ,',15,15)')"/></xsl:attribute>
+                                        <xsl:attribute name="transform"><xsl:value-of select="concat('translate(', 330 + @dist * 35, ',-15) rotate(', @degree - $asc_rotate ,',15,15)')"/></xsl:attribute>
                                     </use>
                                 </g>
                                 <xsl:choose>


### PR DESCRIPTION
This solution is borrowed from the AstroWS project of @Kivutar
