### PR TITLE
Set month and day to 1, so warnings disappear

### DIFF
--- a/src/resources/ui/ag-window.ui
+++ b/src/resources/ui/ag-window.ui
@@ -76,12 +76,14 @@
     <property name="upper">12</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
+    <property name="value">1</property>
   </object>
   <object class="GtkAdjustment" id="day_adjust">
     <property name="lower">1</property>
     <property name="upper">31</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
+    <property name="value">1</property>
   </object>
   <object class="GtkAdjustment" id="hour_adjust">
     <property name="upper">23</property>


### PR DESCRIPTION
This is somewhat cosmetic, a better approach should be found. Fixes #23
