### PR TITLE
Disable chart context menu

### DIFF
--- a/src/ag-window.c
+++ b/src/ag-window.c
@@ -1775,6 +1775,13 @@ ag_window_new(AgApp *app, WebKitUserContentManager *manager)
             TRUE, TRUE, 0
         );
 
+    g_signal_connect(
+            priv->chart_web_view,
+            "context-menu",
+            G_CALLBACK(ag_window_chart_context_cb),
+            NULL
+        );
+
     // TODO: translate this error message!
     webkit_web_view_load_html(
             WEBKIT_WEB_VIEW(priv->chart_web_view),


### PR DESCRIPTION
Commit 2af46ec accidentally re-added chart context menu by removing the
context-menu signal handler from the web view. This patch disables it again.
